### PR TITLE
Add nestead zero more test

### DIFF
--- a/src/nez/main/CommandConfigure.java
+++ b/src/nez/main/CommandConfigure.java
@@ -25,6 +25,9 @@ public class CommandConfigure {
 	// -p konoha.nez
 	public String GrammarFile = null; // default
 
+	// -e "peg rule"
+	public String GrammarText = null;
+
 	// -e, --expr regular expression
 	public String Expression = null;
 
@@ -57,6 +60,7 @@ public class CommandConfigure {
 	void showUsage(String Message) {
 		ConsoleUtils.println("nez <command> optional files");
 		ConsoleUtils.println("  -p | --peg <filename>      Specify an PEGs grammar file");
+		ConsoleUtils.println("  -e                         Specify an PEGs grammar text");
 		ConsoleUtils.println("  -i | --input <filenames>   Specify input files");
 		ConsoleUtils.println("  -t | --text  <string>      Specify an input text");
 		ConsoleUtils.println("  -o | --output <filename>   Specify an output file");
@@ -83,7 +87,7 @@ public class CommandConfigure {
 		ConsoleUtils.exit(0, Message);
 	}
 	
-	void parseCommandOption(String[] args) {
+	public void parseCommandOption(String[] args) {
 		int index = 0;
 		if(args.length > 0) {
 			if(!args[0].startsWith("-")) {
@@ -110,6 +114,10 @@ public class CommandConfigure {
 			}
 			else if ((argument.equals("-p") || argument.equals("--peg")) && (index < args.length)) {
 				GrammarFile = args[index];
+				index = index + 1;
+			}
+			else if (argument.equals("-e") && (index < args.length)) {
+				GrammarText = args[index];
 				index = index + 1;
 			}
 			else if ((argument.equals("-t") || argument.equals("--text")) && (index < args.length)) {
@@ -256,6 +264,10 @@ public class CommandConfigure {
 			} catch (IOException e) {
 				ConsoleUtils.exit(1, "cannot open " + GrammarFile + "; " + e.getMessage());
 			}
+		}
+		if(GrammarText != null) {
+			NezParser p = new NezParser();
+			return p.load(SourceContext.newStringSourceContext(GrammarText), new GrammarChecker(this.OptimizationLevel));
 		}
 		ConsoleUtils.println("unspecifed grammar");
 		return NezParserCombinator.newGrammar();

--- a/unit_test/java/NesteadZeroMoreTest.java
+++ b/unit_test/java/NesteadZeroMoreTest.java
@@ -1,0 +1,22 @@
+import nez.main.Command;
+import nez.main.CommandConfigure;
+
+import org.junit.Test;
+
+
+public class NesteadZeroMoreTest {
+	@Test(timeout=5000)
+	public void test() {
+		final String pegRule = 
+				"File = B*\n" +
+				"B = '1'*";
+		final String[] args = new String[] {
+				"parse", "-t", "111", "-e", pegRule	
+		};
+		CommandConfigure config = new CommandConfigure();
+		config.parseCommandOption(args);
+		Command com = config.getCommand();
+		com.exec(config);
+		// FIXME assert
+	}
+}


### PR DESCRIPTION
This pull request add following topics.
- command lined peg syntax option "-e inlined_peg_syntax"
- NestedZeroMore test

```
File = B*
B = "1"*
```
